### PR TITLE
Fix logger path

### DIFF
--- a/core.py
+++ b/core.py
@@ -23,20 +23,20 @@ def get_debug_logger() -> logging.Logger:
     if not hasattr(get_debug_logger, "cached_logger"):
         logger = logging.getLogger("debug_logger")
         logger.setLevel(logging.DEBUG)
-        handler = logging.FileHandler(
-            os.path.join(
-                os.getenv("USERPROFILE"),
-                "OneDrive",
-                "Documents",
-                "CRYPTO",
-                "PYTHON",
-                "WORK_IN_PROGRESS",
-                "cryptoscanner",
-                "logs",
-                "klines_debug.log"
-            ),
-            mode="w"
+        home = os.path.expanduser("~")
+        log_path = os.path.join(
+            home,
+            "OneDrive",
+            "Documents",
+            "CRYPTO",
+            "PYTHON",
+            "WORK_IN_PROGRESS",
+            "cryptoscanner",
+            "logs",
+            "klines_debug.log",
         )
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        handler = logging.FileHandler(log_path, mode="w")
         handler.setFormatter(logging.Formatter("[%(asctime)s] %(message)s"))
         logger.addHandler(handler)
         get_debug_logger.cached_logger = logger


### PR DESCRIPTION
## Summary
- fix cross-platform log path in core

## Testing
- `pytest test.py -q`
- `pylint core.py scan.py volume_math.py test.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a0e28b3c832182dcdf2c9aff6e9d