### PR TITLE
Implement klines sort caching and tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -154,3 +154,15 @@ def test_calculate_volume_change_4h():
     klines = (baseline * 20) + spike
     result = calculate_volume_change(klines, 240)
     assert result > 400
+
+
+def test_calculate_volume_change_cache_usage():
+    """Ensure sorted klines are cached and reused for identical objects."""
+    core.SORTED_KLINES_CACHE.clear()
+    klines = [[str(i), "", "", "", "", "1"] for i in range(105)]
+
+    calculate_volume_change(klines, 5)
+    assert len(core.SORTED_KLINES_CACHE) == 1
+
+    calculate_volume_change(klines, 5)
+    assert len(core.SORTED_KLINES_CACHE) == 1

--- a/volume_math.py
+++ b/volume_math.py
@@ -1,9 +1,17 @@
 """Volume math module for calculating percentage volume change across kline blocks."""
 
+import core
+
+
 def calculate_volume_change(klines: list, block_size: int) -> float:
     """Calculate % volume change for the latest block vs. previous 20 blocks."""
     try:
-        sorted_klines = sorted(klines, key=lambda k: int(k[0]))
+        k_id = id(klines)
+        if k_id in core.SORTED_KLINES_CACHE:
+            sorted_klines = core.SORTED_KLINES_CACHE[k_id]
+        else:
+            sorted_klines = sorted(klines, key=lambda k: int(k[0]))
+            core.SORTED_KLINES_CACHE[k_id] = sorted_klines
 
         blocks = [
             sorted_klines[i:i + block_size]


### PR DESCRIPTION
## Summary
- cache sorted klines in `calculate_volume_change`
- ensure cache is reused for repeated calls
- add unit test verifying cache usage

## Testing
- `pytest test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a9aed6c08321b0b0c293d71335de