### PR TITLE
Add 24h volume column to Excel output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Bybit Volume Scanner
 
 This project scans Bybit USDT perpetual markets for unusual volume activity.
+The resulting spreadsheet now includes a column showing each pair's total 24​hr trading volume.
 
 ## Installation
 

--- a/scan.py
+++ b/scan.py
@@ -62,6 +62,11 @@ def export_to_excel(df: pd.DataFrame, symbol_order: list, logger: logging.Logger
         green_format = writer.book.add_format({
             "bg_color": "#C6EFCE", "font_color": "#006100"
         })
+        accounting_format = writer.book.add_format({"num_format": "_(* #,##0_);_(* (#,##0);_(* \"-\"??_);_(@_)"})
+
+        if "24h Volume" in df.columns:
+            col_idx = df.columns.get_loc("24h Volume")
+            worksheet.set_column(col_idx, col_idx, None, accounting_format)
 
         for col in range(1, 6):
             col_letter = chr(ord("A") + col)
@@ -117,6 +122,10 @@ def run_scan(logger: logging.Logger) -> None:
     logger.info("Scanning symbols in parallel...")
 
     rows, failed = scan_and_collect_results([s for s, _ in all_symbols], logger)
+
+    volume_map = {symbol: volume for symbol, volume in all_symbols}
+    for row in rows:
+        row["24h Volume"] = volume_map.get(row["Symbol"], 0)
 
     if failed:
         logger.warning("%d symbols failed: %s", len(failed), ", ".join(failed))


### PR DESCRIPTION
## Summary
- show each symbol's total 24h volume in exported Excel
- apply accounting number format to the new column
- document 24h volume column in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841adc0ecec83219d4074a819a1c1f0