### PR TITLE
Merge debug and scan logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ pytest test.py
 
 ## Grouping Debug Logs
 
-Use `group_logs.py` to organise `klines_debug.log` entries so that all lines for
+Use `group_logs.py` to organise `scanlog.txt` entries so that all lines for
 each symbol appear together:
 
 ```bash
-python group_logs.py /path/to/klines_debug.log
+python group_logs.py /path/to/scanlog.txt
 ```
 
 The script writes a new file with `_grouped` appended to the original name.

--- a/core.py
+++ b/core.py
@@ -18,26 +18,29 @@ from volume_math import calculate_volume_change
 KLINE_CACHE = {}
 SORTED_KLINES_CACHE = {}
 
+# Directory where all log files are written
+LOG_DIR = os.path.join(
+    os.path.expanduser("~"),
+    "OneDrive",
+    "Documents",
+    "CRYPTO",
+    "PYTHON",
+    "WORK_IN_PROGRESS",
+    "cryptoscanner",
+    "logs",
+)
+
 def get_debug_logger() -> logging.Logger:
     """Return a memoized logger for debugging kline fetches."""
     if not hasattr(get_debug_logger, "cached_logger"):
         logger = logging.getLogger("debug_logger")
         logger.setLevel(logging.DEBUG)
-        home = os.path.expanduser("~")
-        log_path = os.path.join(
-            home,
-            "OneDrive",
-            "Documents",
-            "CRYPTO",
-            "PYTHON",
-            "WORK_IN_PROGRESS",
-            "cryptoscanner",
-            "logs",
-            "klines_debug.log",
+        os.makedirs(LOG_DIR, exist_ok=True)
+        log_path = os.path.join(LOG_DIR, "scanlog.txt")
+        handler = logging.FileHandler(log_path, mode="a")
+        handler.setFormatter(
+            logging.Formatter("[%(levelname)s] %(asctime)s %(message)s")
         )
-        os.makedirs(os.path.dirname(log_path), exist_ok=True)
-        handler = logging.FileHandler(log_path, mode="w")
-        handler.setFormatter(logging.Formatter("[%(asctime)s] %(message)s"))
         logger.addHandler(handler)
         get_debug_logger.cached_logger = logger
     return get_debug_logger.cached_logger

--- a/group_logs.py
+++ b/group_logs.py
@@ -40,7 +40,7 @@ def group_log_by_symbol(logfile: str, output: str | None = None) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Group kline debug logs by symbol")
-    parser.add_argument("logfile", help="Path to klines_debug.log")
+    parser.add_argument("logfile", help="Path to scanlog.txt")
     parser.add_argument("-o", "--output", help="Output file path")
     args = parser.parse_args()
 

--- a/scan.py
+++ b/scan.py
@@ -19,7 +19,9 @@ def setup_logging() -> logging.Logger:
     logger.handlers.clear()
     fmt = logging.Formatter("[%(levelname)s] %(asctime)s %(message)s")
 
-    fh = logging.FileHandler("scanlog.txt", mode="w")
+    os.makedirs(core.LOG_DIR, exist_ok=True)
+    log_path = os.path.join(core.LOG_DIR, "scanlog.txt")
+    fh = logging.FileHandler(log_path, mode="w")
     fh.setFormatter(fmt)
     logger.addHandler(fh)
 


### PR DESCRIPTION
## Summary
- log scan output to the same directory as debug logs
- write debug messages to the scan log instead of a separate file
- update grouping script and docs for new log location

## Testing
- `pip install -q -r requirements.txt`
- `pytest test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841aff32718832185e8669b90b411b1