### PR TITLE
Add run_checks.py with tqdm progress bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ pip install -r requirements.txt
 
 ## Running Tests
 
-After installing the dependencies, run the unit tests with:
+After installing the dependencies, run `run_checks.py` to execute
+both pylint and pytest with progress bars:
 
 ```bash
-pytest test.py
+python run_checks.py
 ```
 
 ## Grouping Debug Logs

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 tqdm
 xlsxwriter
 pytest
+pylint

--- a/run_checks.py
+++ b/run_checks.py
@@ -1,0 +1,63 @@
+"""Run pylint and pytest with tqdm progress bars."""
+import subprocess
+import sys
+from pathlib import Path
+
+from tqdm import tqdm
+import pytest
+
+PY_FILES = ["core.py", "scan.py", "test.py", "volume_math.py"]
+
+
+def run_pylint() -> None:
+    """Run pylint on all target files with a progress bar."""
+    for path in PY_FILES:
+        if not Path(path).is_file():
+            raise FileNotFoundError(f"Missing required file: {path}")
+
+    with tqdm(total=len(PY_FILES), desc="pylint") as pbar:
+        for path in PY_FILES:
+            result = subprocess.run([
+                "pylint",
+                path,
+            ], text=True, capture_output=True)
+            sys.stdout.write(result.stdout)
+            sys.stdout.flush()
+            if result.returncode != 0:
+                raise SystemExit(f"pylint failed for {path}")
+            pbar.update(1)
+
+
+def run_pytest() -> None:
+    """Run pytest with a tqdm progress bar for tests."""
+
+    class TqdmPlugin:  # pylint: disable=too-few-public-methods
+        """pytest plugin showing progress with tqdm."""
+
+        def __init__(self) -> None:
+            self.pbar = None
+
+        def pytest_collection_modifyitems(self, session, config, items):  # noqa: ARG002
+            self.pbar = tqdm(total=len(items), desc="pytest")
+
+        def pytest_runtest_logreport(self, report):
+            if report.when == "call" and self.pbar:
+                self.pbar.update(1)
+
+        def pytest_sessionfinish(self, session, exitstatus):  # noqa: ARG002
+            if self.pbar:
+                self.pbar.close()
+
+    errno = pytest.main(["test.py"], plugins=[TqdmPlugin()])
+    if errno != 0:
+        raise SystemExit(errno)
+
+
+def main() -> None:
+    """Execute pylint and pytest with progress bars."""
+    run_pylint()
+    run_pytest()
+
+
+if __name__ == "__main__":
+    main()

--- a/scan.py
+++ b/scan.py
@@ -62,7 +62,9 @@ def export_to_excel(df: pd.DataFrame, symbol_order: list, logger: logging.Logger
         green_format = writer.book.add_format({
             "bg_color": "#C6EFCE", "font_color": "#006100"
         })
-        accounting_format = writer.book.add_format({"num_format": "_(* #,##0_);_(* (#,##0);_(* \"-\"??_);_(@_)"})
+        accounting_format = writer.book.add_format({
+            "num_format": "_(* #,##0_);_(* (#,##0);_(* \"-\"??_);_(@_)"
+        })
 
         if "24h Volume" in df.columns:
             col_idx = df.columns.get_loc("24h Volume")
@@ -123,7 +125,7 @@ def run_scan(logger: logging.Logger) -> None:
 
     rows, failed = scan_and_collect_results([s for s, _ in all_symbols], logger)
 
-    volume_map = {symbol: volume for symbol, volume in all_symbols}
+    volume_map = dict(all_symbols)
     for row in rows:
         row["24h Volume"] = volume_map.get(row["Symbol"], 0)
 


### PR DESCRIPTION
## Summary
- add a helper script to run pylint and pytest with tqdm progress bars
- tweak `scan.py` to satisfy pylint
- document the new workflow in README
- list `pylint` in requirements

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b04a13e08321af54886fb0533ddb