### PR TITLE
Fix RUN.bat with run_checks and encoding

### DIFF
--- a/RUN.bat
+++ b/RUN.bat
@@ -3,37 +3,13 @@ cd /d "%~dp0"
 
 setlocal enableextensions enabledelayedexpansion
 
-:: Create logs directory if it doesn't exist
-if not exist "logs" mkdir logs
-
-:: Set paths
-set PYLINT_LOG=logs\pylint.log
-set PYTEST_LOG=logs\pytest.log
-
-:: Run Pylint
-echo Running pylint on all .py files...
-pylint core.py scan.py test.py volume_math.py > "!PYLINT_LOG!"
-type "!PYLINT_LOG!"
-
-:: Check for exact 10.00/10 rating
-findstr /R /C:"Your code has been rated at 10.00/10" "!PYLINT_LOG!" >nul
+:: Run style checks and unit tests
+echo Running lint and tests...
+python run_checks.py
 if errorlevel 1 (
-    echo [ABORTED] Pylint score is less than 10.00/10. Aborting.
+    echo [ABORTED] Lint or tests failed. Aborting.
     pause
     exit /b 1
-)
-
-:: Run Pytest (with -s to allow print debugging output)
-echo Running pytest...
-pytest -s test.py > "!PYTEST_LOG!"
-if errorlevel 1 (
-    type "!PYTEST_LOG!"
-    echo [ABORTED] Pytest failures detected. Aborting.
-    pause
-    exit /b 1
-) else (
-    type "!PYTEST_LOG!"
-    echo All tests passed.
 )
 
 :: Run main script

--- a/scan.py
+++ b/scan.py
@@ -18,7 +18,7 @@ def wait_for_file_close(filename: str, logger: logging.Logger) -> None:
         return
     while True:
         try:
-            with open(filename, "a"):
+            with open(filename, "a", encoding="utf-8"):
                 break
         except OSError:
             logger.warning(


### PR DESCRIPTION
## Summary
- simplify RUN.bat by delegating style/tests to `run_checks.py`
- fix `scan.py` encoding warning to keep pylint score perfect

## Testing
- `pip install -r requirements.txt`
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b3e0f34c8321b62b2f46f7dbce92