### PR TITLE
Fix pylint warnings

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -18,7 +18,7 @@ def wait_for_file_close(filename: str, logger: logging.Logger) -> None:
         return
     while True:
         try:
-            with open(filename, "a"):
+            with open(filename, "a", encoding="utf-8"):
                 break
         except OSError:
             logger.warning(

--- a/volume_math.py
+++ b/volume_math.py
@@ -1,10 +1,10 @@
 """Volume math module for calculating percentage volume change across kline blocks."""
 
-import core
 
 
 def calculate_volume_change(klines: list, block_size: int) -> float:
     """Calculate % volume change for the latest block vs. previous 20 blocks."""
+    import core  # pylint: disable=import-outside-toplevel
     try:
         k_id = id(klines)
         if k_id in core.SORTED_KLINES_CACHE:


### PR DESCRIPTION
## Summary
- fix unspecified encoding in scan.py
- avoid cyclic import by lazily importing in volume_math

## Testing
- `python run_checks.py`

------
https://chatgpt.com/codex/tasks/task_e_6841b416dcf483219dfb60447f6dbf2f